### PR TITLE
No longer validate the secret during send and receive.  Instead, leav…

### DIFF
--- a/ClientTest/Program.cs
+++ b/ClientTest/Program.cs
@@ -16,13 +16,11 @@ namespace ClientTest
 				ShowUsage();
 				return;
 			}
-
+			
 			Authenticate(args).ContinueWith(task => 
 			{
 				if (task.IsFaulted)
 					Console.WriteLine("Error : " + task.Exception.Message);
-
-				Console.ReadLine();
 			});
 		}
 
@@ -33,7 +31,12 @@ namespace ClientTest
 			authPacket.SetAttribute(new VendorSpecificAttribute(10135, 1, UTF8Encoding.UTF8.GetBytes("Testing")));
 			authPacket.SetAttribute(new VendorSpecificAttribute(10135, 2, new[] { (byte)7 }));
 			RadiusPacket receivedPacket = await rc.SendAndReceivePacket(authPacket);
+
 			if (receivedPacket == null) throw new Exception("Can't contact remote radius server !");
+
+			if (!rc.VerifyAuthenticator(authPacket, receivedPacket))
+			   Console.WriteLine("Bad secret!");
+
 			switch (receivedPacket.PacketType)
 			{
 				case RadiusCode.ACCESS_ACCEPT:

--- a/Radius/RadiusClient.cs
+++ b/Radius/RadiusClient.cs
@@ -112,7 +112,7 @@ namespace FP.Radius
 						var result = udpClient.Receive(ref endPoint);
 						RadiusPacket receivedPacket = new RadiusPacket(result);
 
-						if (receivedPacket.Valid && VerifyAuthenticator(packet, receivedPacket))
+						if (receivedPacket.Valid)
 							return receivedPacket;
 					}
 					catch (SocketException)
@@ -130,7 +130,7 @@ namespace FP.Radius
 		#endregion
 
 		#region Private Methods
-		private bool VerifyAuthenticator(RadiusPacket requestedPacket, RadiusPacket receivedPacket)
+		public bool VerifyAuthenticator(RadiusPacket requestedPacket, RadiusPacket receivedPacket)
 		{
 			return requestedPacket.Identifier == receivedPacket.Identifier 
 				&& receivedPacket.Authenticator.SequenceEqual(Utils.ResponseAuthenticator(receivedPacket.RawData, requestedPacket.Authenticator, _SharedSecret));


### PR DESCRIPTION
…e it up to the caller to check after a response has been received from the RADIUS endpoint.