### PR TITLE
Return received packet even if Authenticator fails

### DIFF
--- a/ClientTest/Program.cs
+++ b/ClientTest/Program.cs
@@ -5,68 +5,68 @@ using System.Threading.Tasks;
 
 namespace ClientTest
 {
-    internal class Program
-    {
-        private static void Main(string[] args)
-        {
-            if (args.Length != 4)
-            {
-                ShowUsage();
-                return;
-            }
+	internal class Program
+	{
+		private static void Main(string[] args)
+		{
+			if (args.Length != 4)
+			{
+				ShowUsage();
+				return;
+			}
 
-            //args = new string[4];
-            //args[0] = "192.168.1.1";
-            //args[1] = "secret";
-            //args[2] = "username";
-            //args[3] = "password";
+			//args = new string[4];
+			//args[0] = "192.168.1.1";
+			//args[1] = "secret";
+			//args[2] = "username";
+			//args[3] = "password";
 
-            try
-            {
-                Authenticate(args).Wait();
-            }
-            catch (Exception e)
-            {
-                Console.WriteLine(e);
-            }
+			try
+			{
+				Authenticate(args).Wait();
+			}
+			catch (Exception e)
+			{
+				Console.WriteLine(e);
+			}
 
-            Console.WriteLine("Press any key to exit...");
-            Console.ReadLine();
-        }
+			Console.WriteLine("Press any key to exit...");
+			Console.ReadLine();
+		}
 
-        private async static Task Authenticate(string[] args)
-        {
-            RadiusClient rc = new RadiusClient(args[0], args[1]);
-            RadiusPacket authPacket = rc.Authenticate(args[2], args[3]);
-            authPacket.SetAttribute(new VendorSpecificAttribute(10135, 1, UTF8Encoding.UTF8.GetBytes("Testing")));
-            authPacket.SetAttribute(new VendorSpecificAttribute(10135, 2, new[] { (byte)7 }));
-            RadiusPacket receivedPacket = await rc.SendAndReceivePacket(authPacket);
-            if (receivedPacket == null) throw new Exception("Can't contact remote radius server !");
+		private async static Task Authenticate(string[] args)
+		{
+			RadiusClient rc = new RadiusClient(args[0], args[1]);
+			RadiusPacket authPacket = rc.Authenticate(args[2], args[3]);
+			authPacket.SetAttribute(new VendorSpecificAttribute(10135, 1, UTF8Encoding.UTF8.GetBytes("Testing")));
+			authPacket.SetAttribute(new VendorSpecificAttribute(10135, 2, new[] { (byte)7 }));
+			RadiusPacket receivedPacket = await rc.SendAndReceivePacket(authPacket);
+			if (receivedPacket == null) throw new Exception("Can't contact remote radius server !");
 
-            switch (receivedPacket.PacketType)
-            {
-                case RadiusCode.ACCESS_ACCEPT:
-                    Console.WriteLine("Access-Accept");
-                    foreach (var attr in receivedPacket.Attributes)
-                        Console.WriteLine(attr.Type.ToString() + " = " + attr.Value);
-                    break;
-                case RadiusCode.ACCESS_CHALLENGE:
-                    Console.WriteLine("Access-Challenge");
-                    break;
-                case RadiusCode.ACCESS_REJECT:
-                    Console.WriteLine("Access-Reject");
-                    if (!rc.VerifyAuthenticator(authPacket, receivedPacket))
-                        Console.WriteLine("Authenticator check failed: Check your secret");
-                    break;
-                default:
-                    Console.WriteLine("Rejected");
-                    break;
-            }
-        }
+			switch (receivedPacket.PacketType)
+			{
+				case RadiusCode.ACCESS_ACCEPT:
+					Console.WriteLine("Access-Accept");
+					foreach (var attr in receivedPacket.Attributes)
+						Console.WriteLine(attr.Type.ToString() + " = " + attr.Value);
+					break;
+				case RadiusCode.ACCESS_CHALLENGE:
+					Console.WriteLine("Access-Challenge");
+					break;
+				case RadiusCode.ACCESS_REJECT:
+					Console.WriteLine("Access-Reject");
+					if (!rc.VerifyAuthenticator(authPacket, receivedPacket))
+						Console.WriteLine("Authenticator check failed: Check your secret");
+					break;
+				default:
+					Console.WriteLine("Rejected");
+					break;
+			}
+		}
 
-        private static void ShowUsage()
-        {
-            Console.WriteLine("Usage : ClientTest.exe hostname sharedsecret username password");
-        }
-    }
+		private static void ShowUsage()
+		{
+			Console.WriteLine("Usage : ClientTest.exe hostname sharedsecret username password");
+		}
+	}
 }

--- a/ClientTest/Program.cs
+++ b/ClientTest/Program.cs
@@ -1,58 +1,72 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using FP.Radius;
+﻿using FP.Radius;
+using System;
 using System.Text;
 using System.Threading.Tasks;
 
 namespace ClientTest
 {
-	internal class Program
-	{
-		private static void Main(string[] args)
-		{
-			if (args.Length != 4)
-			{
-				ShowUsage();
-				return;
-			}
+    internal class Program
+    {
+        private static void Main(string[] args)
+        {
+            if (args.Length != 4)
+            {
+                ShowUsage();
+                return;
+            }
 
-			Authenticate(args).ContinueWith(task => 
-			{
-				if (task.IsFaulted)
-					Console.WriteLine("Error : " + task.Exception.Message);
+            //args = new string[4];
+            //args[0] = "192.168.1.1";
+            //args[1] = "secret";
+            //args[2] = "username";
+            //args[3] = "password";
 
-				Console.ReadLine();
-			});
-		}
+            try
+            {
+                Authenticate(args).Wait();
+            }
+            catch (Exception e)
+            {
+                Console.WriteLine(e);
+            }
 
-		private async static Task Authenticate(string[] args)
-		{
-			RadiusClient rc = new RadiusClient(args[0], args[1]);
-			RadiusPacket authPacket = rc.Authenticate(args[2], args[3]);
-			authPacket.SetAttribute(new VendorSpecificAttribute(10135, 1, UTF8Encoding.UTF8.GetBytes("Testing")));
-			authPacket.SetAttribute(new VendorSpecificAttribute(10135, 2, new[] { (byte)7 }));
-			RadiusPacket receivedPacket = await rc.SendAndReceivePacket(authPacket);
-			if (receivedPacket == null) throw new Exception("Can't contact remote radius server !");
-			switch (receivedPacket.PacketType)
-			{
-				case RadiusCode.ACCESS_ACCEPT:
-					Console.WriteLine("Accepted");
-					foreach (var attr in receivedPacket.Attributes)
-						Console.WriteLine(attr.Type.ToString() + " = " + attr.Value);
-					break;
-				case RadiusCode.ACCESS_CHALLENGE:
-					Console.WriteLine("Challenged");
-					break;
-				default:
-					Console.WriteLine("Rejected");
-					break;
-			}	
-		}
+            Console.WriteLine("Press any key to exit...");
+            Console.ReadLine();
+        }
 
-		private static void ShowUsage()
-		{
-			Console.WriteLine("Usage : ClientTest.exe hostname sharedsecret username password");
-		}
-	}
+        private async static Task Authenticate(string[] args)
+        {
+            RadiusClient rc = new RadiusClient(args[0], args[1]);
+            RadiusPacket authPacket = rc.Authenticate(args[2], args[3]);
+            authPacket.SetAttribute(new VendorSpecificAttribute(10135, 1, UTF8Encoding.UTF8.GetBytes("Testing")));
+            authPacket.SetAttribute(new VendorSpecificAttribute(10135, 2, new[] { (byte)7 }));
+            RadiusPacket receivedPacket = await rc.SendAndReceivePacket(authPacket);
+            if (receivedPacket == null) throw new Exception("Can't contact remote radius server !");
+
+            switch (receivedPacket.PacketType)
+            {
+                case RadiusCode.ACCESS_ACCEPT:
+                    Console.WriteLine("Access-Accept");
+                    foreach (var attr in receivedPacket.Attributes)
+                        Console.WriteLine(attr.Type.ToString() + " = " + attr.Value);
+                    break;
+                case RadiusCode.ACCESS_CHALLENGE:
+                    Console.WriteLine("Access-Challenge");
+                    break;
+                case RadiusCode.ACCESS_REJECT:
+                    Console.WriteLine("Access-Reject");
+                    if (!rc.VerifyAuthenticator(authPacket, receivedPacket))
+                        Console.WriteLine("Authenticator check failed: Check your secret");
+                    break;
+                default:
+                    Console.WriteLine("Rejected");
+                    break;
+            }
+        }
+
+        private static void ShowUsage()
+        {
+            Console.WriteLine("Usage : ClientTest.exe hostname sharedsecret username password");
+        }
+    }
 }

--- a/Radius/RadiusClient.cs
+++ b/Radius/RadiusClient.cs
@@ -9,153 +9,153 @@ using System.Threading.Tasks;
 
 namespace FP.Radius
 {
-    public class RadiusClient
-    {
-        #region Constants
-        private const int DEFAULT_RETRIES = 3;
-        private const uint DEFAULT_AUTH_PORT = 1812;
-        private const uint DEFAULT_ACCT_PORT = 1813;
-        private const int DEFAULT_SOCKET_TIMEOUT = 3000;
-        #endregion
+	public class RadiusClient
+	{
+		#region Constants
+		private const int DEFAULT_RETRIES = 3;
+		private const uint DEFAULT_AUTH_PORT = 1812;
+		private const uint DEFAULT_ACCT_PORT = 1813;
+		private const int DEFAULT_SOCKET_TIMEOUT = 3000;
+		#endregion
 
-        #region Private
-        private string _SharedSecret = String.Empty;
-        private string _HostName = String.Empty;
-        private uint _AuthPort = DEFAULT_AUTH_PORT;
-        private uint _AcctPort = DEFAULT_ACCT_PORT;
-        private uint _AuthRetries = DEFAULT_RETRIES;
-        private uint _AcctRetries = DEFAULT_RETRIES;
-        private int _SocketTimeout = DEFAULT_SOCKET_TIMEOUT;
-        private IPEndPoint _LocalEndPoint;
-        #endregion
+		#region Private
+		private string _SharedSecret = String.Empty;
+		private string _HostName = String.Empty;
+		private uint _AuthPort = DEFAULT_AUTH_PORT;
+		private uint _AcctPort = DEFAULT_ACCT_PORT;
+		private uint _AuthRetries = DEFAULT_RETRIES;
+		private uint _AcctRetries = DEFAULT_RETRIES;
+		private int _SocketTimeout = DEFAULT_SOCKET_TIMEOUT;
+		private IPEndPoint _LocalEndPoint;
+		#endregion
 
-        #region Properties
-        public int SocketTimeout
-        {
-            get { return _SocketTimeout; }
-            set { _SocketTimeout = value; }
-        }
-        #endregion
+		#region Properties
+		public int SocketTimeout
+		{
+			get { return _SocketTimeout; }
+			set { _SocketTimeout = value; }
+		}
+		#endregion
 
-        #region Constructors
-        public RadiusClient(string hostName, string sharedSecret,
-                            int sockTimeout = DEFAULT_SOCKET_TIMEOUT,
-                            uint authPort = DEFAULT_AUTH_PORT,
-                            uint acctPort = DEFAULT_ACCT_PORT,
-                            IPEndPoint localEndPoint = null)
-        {
-            _HostName = hostName;
-            _AuthPort = authPort;
-            _AcctPort = acctPort;
-            _LocalEndPoint = localEndPoint;
-            _SharedSecret = sharedSecret;
-            _SocketTimeout = sockTimeout;
-        }
-        #endregion
+		#region Constructors
+		public RadiusClient(string hostName, string sharedSecret,
+							int sockTimeout = DEFAULT_SOCKET_TIMEOUT,
+							uint authPort = DEFAULT_AUTH_PORT,
+							uint acctPort = DEFAULT_ACCT_PORT,
+							IPEndPoint localEndPoint = null)
+		{
+			_HostName = hostName;
+			_AuthPort = authPort;
+			_AcctPort = acctPort;
+			_LocalEndPoint = localEndPoint;
+			_SharedSecret = sharedSecret;
+			_SocketTimeout = sockTimeout;
+		}
+		#endregion
 
-        #region Public Methods
-        public RadiusPacket Authenticate(string username, string password)
-        {
-            RadiusPacket packet = new RadiusPacket(RadiusCode.ACCESS_REQUEST);
-            packet.SetAuthenticator(_SharedSecret);
-            byte[] encryptedPass = Utils.EncodePapPassword(Encoding.ASCII.GetBytes(password), packet.Authenticator, _SharedSecret);
-            packet.SetAttribute(new RadiusAttribute(RadiusAttributeType.USER_NAME, Encoding.ASCII.GetBytes(username)));
-            packet.SetAttribute(new RadiusAttribute(RadiusAttributeType.USER_PASSWORD, encryptedPass));
-            return packet;
-        }
+		#region Public Methods
+		public RadiusPacket Authenticate(string username, string password)
+		{
+			RadiusPacket packet = new RadiusPacket(RadiusCode.ACCESS_REQUEST);
+			packet.SetAuthenticator(_SharedSecret);
+			byte[] encryptedPass = Utils.EncodePapPassword(Encoding.ASCII.GetBytes(password), packet.Authenticator, _SharedSecret);
+			packet.SetAttribute(new RadiusAttribute(RadiusAttributeType.USER_NAME, Encoding.ASCII.GetBytes(username)));
+			packet.SetAttribute(new RadiusAttribute(RadiusAttributeType.USER_PASSWORD, encryptedPass));
+			return packet;
+		}
 
-        public async Task<RadiusPacket> SendAndReceivePacket(RadiusPacket packet, int retries = DEFAULT_RETRIES)
-        {
-            using (UdpClient udpClient = new UdpClient())
-            {
-                udpClient.Client.SetSocketOption(SocketOptionLevel.Socket, SocketOptionName.ReceiveTimeout, _SocketTimeout);
+		public async Task<RadiusPacket> SendAndReceivePacket(RadiusPacket packet, int retries = DEFAULT_RETRIES)
+		{
+			using (UdpClient udpClient = new UdpClient())
+			{
+				udpClient.Client.SetSocketOption(SocketOptionLevel.Socket, SocketOptionName.ReceiveTimeout, _SocketTimeout);
 
-                IPAddress hostIP = null;
+				IPAddress hostIP = null;
 
-                try
-                {
-                    // Starting with Vista, we are able to bind to a local endpoint to guarantee the packet
-                    // will be sent out a particular interface
-                    // This is explained in the following blog
-                    // http://blogs.technet.com/b/networking/archive/2009/04/25/source-ip-address-selection-on-a-multi-homed-windows-computer.aspx
-                    if (_LocalEndPoint != null)
-                        udpClient.Client.Bind(_LocalEndPoint);
+				try
+				{
+					// Starting with Vista, we are able to bind to a local endpoint to guarantee the packet
+					// will be sent out a particular interface
+					// This is explained in the following blog
+					// http://blogs.technet.com/b/networking/archive/2009/04/25/source-ip-address-selection-on-a-multi-homed-windows-computer.aspx
+					if (_LocalEndPoint != null)
+						udpClient.Client.Bind(_LocalEndPoint);
 
-                    if (!IPAddress.TryParse(_HostName, out hostIP))
-                    {
-                        //Try performing a DNS lookup
-                        var host = Dns.GetHostEntry(_HostName);
-                        hostIP = host.AddressList.FirstOrDefault(a => a.AddressFamily == AddressFamily.InterNetwork);
-                        if (hostIP == null)
-                            throw new Exception("Resolving " + _HostName + " returned no hits in DNS");
+					if (!IPAddress.TryParse(_HostName, out hostIP))
+					{
+						//Try performing a DNS lookup
+						var host = Dns.GetHostEntry(_HostName);
+						hostIP = host.AddressList.FirstOrDefault(a => a.AddressFamily == AddressFamily.InterNetwork);
+						if (hostIP == null)
+							throw new Exception("Resolving " + _HostName + " returned no hits in DNS");
 
-                    }
-                }
-                catch (SocketException e)
-                {
-                    int hr = Marshal.GetHRForException(e);
-                    string hexValue = hr.ToString("X");
+					}
+				}
+				catch (SocketException e)
+				{
+					int hr = Marshal.GetHRForException(e);
+					string hexValue = hr.ToString("X");
 
-                    //The requested name is valid, but no data of the requested type was found
-                    if (hexValue == "80004005")
-                        return null;
-                }
+					//The requested name is valid, but no data of the requested type was found
+					if (hexValue == "80004005")
+						return null;
+				}
 
-                var endPoint = new IPEndPoint(hostIP, (int)_AuthPort);
-                int numberOfAttempts = 0;
+				var endPoint = new IPEndPoint(hostIP, (int)_AuthPort);
+				int numberOfAttempts = 0;
 
-                do
-                {
-                    try
-                    {
-                        await udpClient.SendAsync(packet.RawData, packet.RawData.Length, endPoint);
+				do
+				{
+					try
+					{
+						await udpClient.SendAsync(packet.RawData, packet.RawData.Length, endPoint);
 
-                        // Using the synchronous method for the timeout features
-                        var result = udpClient.Receive(ref endPoint);
-                        RadiusPacket receivedPacket = new RadiusPacket(result);
+						// Using the synchronous method for the timeout features
+						var result = udpClient.Receive(ref endPoint);
+						RadiusPacket receivedPacket = new RadiusPacket(result);
 
-                        if (receivedPacket.Valid)
-                            return receivedPacket;
-                    }
-                    catch (SocketException)
-                    {
-                        //Server isn't responding
-                    }
+						if (receivedPacket.Valid)
+							return receivedPacket;
+					}
+					catch (SocketException)
+					{
+						//Server isn't responding
+					}
 
-                    numberOfAttempts++;
+					numberOfAttempts++;
 
-                } while (numberOfAttempts < retries);
-            }
+				} while (numberOfAttempts < retries);
+			}
 
-            return null;
-        }
-        #endregion
+			return null;
+		}
+		#endregion
 
-        #region Private Methods
-        public bool VerifyAuthenticator(RadiusPacket requestedPacket, RadiusPacket receivedPacket)
-        {
-            return requestedPacket.Identifier == receivedPacket.Identifier
-                && receivedPacket.Authenticator.SequenceEqual(Utils.ResponseAuthenticator(receivedPacket.RawData, requestedPacket.Authenticator, _SharedSecret));
-        }
+		#region Private Methods
+		public bool VerifyAuthenticator(RadiusPacket requestedPacket, RadiusPacket receivedPacket)
+		{
+			return requestedPacket.Identifier == receivedPacket.Identifier
+				&& receivedPacket.Authenticator.SequenceEqual(Utils.ResponseAuthenticator(receivedPacket.RawData, requestedPacket.Authenticator, _SharedSecret));
+		}
 
-        public static bool VerifyAccountingAuthenticator(byte[] radiusPacket, string secret)
-        {
-            var secretBytes = Encoding.ASCII.GetBytes(secret);
+		public static bool VerifyAccountingAuthenticator(byte[] radiusPacket, string secret)
+		{
+			var secretBytes = Encoding.ASCII.GetBytes(secret);
 
-            byte[] sum = new byte[radiusPacket.Length + secretBytes.Length];
+			byte[] sum = new byte[radiusPacket.Length + secretBytes.Length];
 
-            byte[] authenticator = new byte[16];
-            Array.Copy(radiusPacket, 4, authenticator, 0, 16);
+			byte[] authenticator = new byte[16];
+			Array.Copy(radiusPacket, 4, authenticator, 0, 16);
 
-            Array.Copy(radiusPacket, 0, sum, 0, radiusPacket.Length);
-            Array.Copy(secretBytes, 0, sum, radiusPacket.Length, secretBytes.Length);
-            Array.Clear(sum, 4, 16);
+			Array.Copy(radiusPacket, 0, sum, 0, radiusPacket.Length);
+			Array.Copy(secretBytes, 0, sum, radiusPacket.Length, secretBytes.Length);
+			Array.Clear(sum, 4, 16);
 
-            MD5 md5 = new MD5CryptoServiceProvider();
+			MD5 md5 = new MD5CryptoServiceProvider();
 
-            var hash = md5.ComputeHash(sum, 0, sum.Length);
-            return authenticator.SequenceEqual(hash);
-        }
-        #endregion
-    }
+			var hash = md5.ComputeHash(sum, 0, sum.Length);
+			return authenticator.SequenceEqual(hash);
+		}
+		#endregion
+	}
 }

--- a/Radius/RadiusClient.cs
+++ b/Radius/RadiusClient.cs
@@ -1,163 +1,161 @@
 using System;
-using System.IO;
 using System.Linq;
+using System.Net;
+using System.Net.Sockets;
 using System.Runtime.InteropServices;
 using System.Security.Cryptography;
 using System.Text;
-using System.Net;
-using System.Net.Sockets;
-using System.Threading;
 using System.Threading.Tasks;
 
 namespace FP.Radius
 {
-	public class RadiusClient
-	{
-		#region Constants
-		private const int DEFAULT_RETRIES = 3;
-		private const uint DEFAULT_AUTH_PORT = 1812;
-		private const uint DEFAULT_ACCT_PORT = 1813;
-		private const int DEFAULT_SOCKET_TIMEOUT = 3000;
-		#endregion
+    public class RadiusClient
+    {
+        #region Constants
+        private const int DEFAULT_RETRIES = 3;
+        private const uint DEFAULT_AUTH_PORT = 1812;
+        private const uint DEFAULT_ACCT_PORT = 1813;
+        private const int DEFAULT_SOCKET_TIMEOUT = 3000;
+        #endregion
 
-		#region Private
-		private string _SharedSecret = String.Empty;
-		private string _HostName = String.Empty;
-		private uint _AuthPort = DEFAULT_AUTH_PORT;
-		private uint _AcctPort = DEFAULT_ACCT_PORT;
-		private uint _AuthRetries = DEFAULT_RETRIES;
-		private uint _AcctRetries = DEFAULT_RETRIES;
-		private int _SocketTimeout = DEFAULT_SOCKET_TIMEOUT;
-		private IPEndPoint _LocalEndPoint;
-		#endregion
+        #region Private
+        private string _SharedSecret = String.Empty;
+        private string _HostName = String.Empty;
+        private uint _AuthPort = DEFAULT_AUTH_PORT;
+        private uint _AcctPort = DEFAULT_ACCT_PORT;
+        private uint _AuthRetries = DEFAULT_RETRIES;
+        private uint _AcctRetries = DEFAULT_RETRIES;
+        private int _SocketTimeout = DEFAULT_SOCKET_TIMEOUT;
+        private IPEndPoint _LocalEndPoint;
+        #endregion
 
-		#region Properties
-		public int SocketTimeout
-		{
-			get { return _SocketTimeout; }
-			set { _SocketTimeout = value; }
-		}
-		#endregion
+        #region Properties
+        public int SocketTimeout
+        {
+            get { return _SocketTimeout; }
+            set { _SocketTimeout = value; }
+        }
+        #endregion
 
-		#region Constructors
-		public RadiusClient(string hostName, string sharedSecret, 
-							int sockTimeout = DEFAULT_SOCKET_TIMEOUT, 
-							uint authPort = DEFAULT_AUTH_PORT, 
-							uint acctPort = DEFAULT_ACCT_PORT,
-							IPEndPoint localEndPoint = null)
-		{
-			_HostName = hostName;
-			_AuthPort = authPort;
-			_AcctPort = acctPort;
-			_LocalEndPoint = localEndPoint;
-			_SharedSecret = sharedSecret;
-			_SocketTimeout = sockTimeout;
-		}
-		#endregion
+        #region Constructors
+        public RadiusClient(string hostName, string sharedSecret,
+                            int sockTimeout = DEFAULT_SOCKET_TIMEOUT,
+                            uint authPort = DEFAULT_AUTH_PORT,
+                            uint acctPort = DEFAULT_ACCT_PORT,
+                            IPEndPoint localEndPoint = null)
+        {
+            _HostName = hostName;
+            _AuthPort = authPort;
+            _AcctPort = acctPort;
+            _LocalEndPoint = localEndPoint;
+            _SharedSecret = sharedSecret;
+            _SocketTimeout = sockTimeout;
+        }
+        #endregion
 
-		#region Public Methods
-		public RadiusPacket Authenticate(string username, string password)
-		{
-			RadiusPacket packet = new RadiusPacket(RadiusCode.ACCESS_REQUEST);
-			packet.SetAuthenticator(_SharedSecret);
-			byte[] encryptedPass = Utils.EncodePapPassword(Encoding.ASCII.GetBytes(password), packet.Authenticator, _SharedSecret);
-			packet.SetAttribute(new RadiusAttribute(RadiusAttributeType.USER_NAME, Encoding.ASCII.GetBytes(username)));
-			packet.SetAttribute(new RadiusAttribute(RadiusAttributeType.USER_PASSWORD, encryptedPass));
-			return packet;
-		}
+        #region Public Methods
+        public RadiusPacket Authenticate(string username, string password)
+        {
+            RadiusPacket packet = new RadiusPacket(RadiusCode.ACCESS_REQUEST);
+            packet.SetAuthenticator(_SharedSecret);
+            byte[] encryptedPass = Utils.EncodePapPassword(Encoding.ASCII.GetBytes(password), packet.Authenticator, _SharedSecret);
+            packet.SetAttribute(new RadiusAttribute(RadiusAttributeType.USER_NAME, Encoding.ASCII.GetBytes(username)));
+            packet.SetAttribute(new RadiusAttribute(RadiusAttributeType.USER_PASSWORD, encryptedPass));
+            return packet;
+        }
 
-		public async Task<RadiusPacket> SendAndReceivePacket(RadiusPacket packet, int retries = DEFAULT_RETRIES)
-		{
-			using (UdpClient udpClient = new UdpClient())
-			{
-				udpClient.Client.SetSocketOption(SocketOptionLevel.Socket, SocketOptionName.ReceiveTimeout, _SocketTimeout);
+        public async Task<RadiusPacket> SendAndReceivePacket(RadiusPacket packet, int retries = DEFAULT_RETRIES)
+        {
+            using (UdpClient udpClient = new UdpClient())
+            {
+                udpClient.Client.SetSocketOption(SocketOptionLevel.Socket, SocketOptionName.ReceiveTimeout, _SocketTimeout);
 
-				IPAddress hostIP = null;
+                IPAddress hostIP = null;
 
-				try
-				{
-					// Starting with Vista, we are able to bind to a local endpoint to guarantee the packet
-					// will be sent out a particular interface
-					// This is explained in the following blog
-					// http://blogs.technet.com/b/networking/archive/2009/04/25/source-ip-address-selection-on-a-multi-homed-windows-computer.aspx
-					if(_LocalEndPoint != null)
-						udpClient.Client.Bind(_LocalEndPoint);
-					
-					if(!IPAddress.TryParse(_HostName, out hostIP))
-					{
-						//Try performing a DNS lookup
-						var host = Dns.GetHostEntry(_HostName);
-						hostIP = host.AddressList.FirstOrDefault(a => a.AddressFamily == AddressFamily.InterNetwork);
-						if (hostIP == null)
-							throw new Exception("Resolving " + _HostName + " returned no hits in DNS");
+                try
+                {
+                    // Starting with Vista, we are able to bind to a local endpoint to guarantee the packet
+                    // will be sent out a particular interface
+                    // This is explained in the following blog
+                    // http://blogs.technet.com/b/networking/archive/2009/04/25/source-ip-address-selection-on-a-multi-homed-windows-computer.aspx
+                    if (_LocalEndPoint != null)
+                        udpClient.Client.Bind(_LocalEndPoint);
 
-					}
-				}
-				catch (SocketException e)
-				{
-					int hr = Marshal.GetHRForException(e);
-					string hexValue = hr.ToString("X");
+                    if (!IPAddress.TryParse(_HostName, out hostIP))
+                    {
+                        //Try performing a DNS lookup
+                        var host = Dns.GetHostEntry(_HostName);
+                        hostIP = host.AddressList.FirstOrDefault(a => a.AddressFamily == AddressFamily.InterNetwork);
+                        if (hostIP == null)
+                            throw new Exception("Resolving " + _HostName + " returned no hits in DNS");
 
-					//The requested name is valid, but no data of the requested type was found
-					if (hexValue == "80004005")
-						return null;
-				}
+                    }
+                }
+                catch (SocketException e)
+                {
+                    int hr = Marshal.GetHRForException(e);
+                    string hexValue = hr.ToString("X");
 
-				var endPoint = new IPEndPoint(hostIP, (int)_AuthPort);
-				int numberOfAttempts = 0;
+                    //The requested name is valid, but no data of the requested type was found
+                    if (hexValue == "80004005")
+                        return null;
+                }
 
-				do
-				{
-					await udpClient.SendAsync(packet.RawData, packet.RawData.Length, endPoint);
+                var endPoint = new IPEndPoint(hostIP, (int)_AuthPort);
+                int numberOfAttempts = 0;
 
-					try
-					{
-						// Using the synchronous method for the timeout features
-						var result = udpClient.Receive(ref endPoint);
-						RadiusPacket receivedPacket = new RadiusPacket(result);
+                do
+                {
+                    try
+                    {
+                        await udpClient.SendAsync(packet.RawData, packet.RawData.Length, endPoint);
 
-						if (receivedPacket.Valid && VerifyAuthenticator(packet, receivedPacket))
-							return receivedPacket;
-					}
-					catch (SocketException)
-					{
-						//Server isn't responding
-					}
+                        // Using the synchronous method for the timeout features
+                        var result = udpClient.Receive(ref endPoint);
+                        RadiusPacket receivedPacket = new RadiusPacket(result);
 
-					numberOfAttempts++;
+                        if (receivedPacket.Valid)
+                            return receivedPacket;
+                    }
+                    catch (SocketException)
+                    {
+                        //Server isn't responding
+                    }
 
-				} while (numberOfAttempts < retries);
-			}
+                    numberOfAttempts++;
 
-			return null;
-		}
-		#endregion
+                } while (numberOfAttempts < retries);
+            }
 
-		#region Private Methods
-		private bool VerifyAuthenticator(RadiusPacket requestedPacket, RadiusPacket receivedPacket)
-		{
-			return requestedPacket.Identifier == receivedPacket.Identifier 
-				&& receivedPacket.Authenticator.SequenceEqual(Utils.ResponseAuthenticator(receivedPacket.RawData, requestedPacket.Authenticator, _SharedSecret));
-		}
+            return null;
+        }
+        #endregion
 
-		public static bool VerifyAccountingAuthenticator(byte[] radiusPacket, string secret)
-		{
-			var secretBytes = Encoding.ASCII.GetBytes(secret);
+        #region Private Methods
+        public bool VerifyAuthenticator(RadiusPacket requestedPacket, RadiusPacket receivedPacket)
+        {
+            return requestedPacket.Identifier == receivedPacket.Identifier
+                && receivedPacket.Authenticator.SequenceEqual(Utils.ResponseAuthenticator(receivedPacket.RawData, requestedPacket.Authenticator, _SharedSecret));
+        }
 
-			byte[] sum = new byte[radiusPacket.Length + secretBytes.Length];
+        public static bool VerifyAccountingAuthenticator(byte[] radiusPacket, string secret)
+        {
+            var secretBytes = Encoding.ASCII.GetBytes(secret);
 
-			byte[] authenticator = new byte[16];
-			Array.Copy(radiusPacket, 4, authenticator, 0, 16);
+            byte[] sum = new byte[radiusPacket.Length + secretBytes.Length];
 
-			Array.Copy(radiusPacket, 0, sum, 0, radiusPacket.Length);
-			Array.Copy(secretBytes, 0, sum, radiusPacket.Length, secretBytes.Length);
-			Array.Clear(sum, 4, 16);
+            byte[] authenticator = new byte[16];
+            Array.Copy(radiusPacket, 4, authenticator, 0, 16);
 
-			MD5 md5 = new MD5CryptoServiceProvider();
+            Array.Copy(radiusPacket, 0, sum, 0, radiusPacket.Length);
+            Array.Copy(secretBytes, 0, sum, radiusPacket.Length, secretBytes.Length);
+            Array.Clear(sum, 4, 16);
 
-			var hash = md5.ComputeHash(sum, 0, sum.Length);
-			return authenticator.SequenceEqual(hash);
-		}
-		#endregion
-	}
+            MD5 md5 = new MD5CryptoServiceProvider();
+
+            var hash = md5.ComputeHash(sum, 0, sum.Length);
+            return authenticator.SequenceEqual(hash);
+        }
+        #endregion
+    }
 }

--- a/Radius/RadiusPacket.cs
+++ b/Radius/RadiusPacket.cs
@@ -1,6 +1,5 @@
 using System;
 using System.Collections.Generic;
-using System.Runtime.InteropServices;
 
 namespace FP.Radius
 {
@@ -29,14 +28,14 @@ namespace FP.Radius
 		public byte Identifier { get; private set; }
 		public byte[] Header { get; private set; }
 		public bool Valid { get; private set; }
-		
+
 		public NasPortType NasPortType
 		{
 			get { return _NasPortType; }
 			set
 			{
 				_NasPortType = value;
-				_Attributes.Add(new RadiusAttribute(RadiusAttributeType.NAS_PORT_TYPE, BitConverter.GetBytes((int) value)));
+				_Attributes.Add(new RadiusAttribute(RadiusAttributeType.NAS_PORT_TYPE, BitConverter.GetBytes((int)value)));
 			}
 		}
 
@@ -58,7 +57,7 @@ namespace FP.Radius
 			PacketType = packetType;
 			Identifier = (Guid.NewGuid().ToByteArray())[0];
 			_Length = RADIUS_HEADER_LENGTH;
-			
+
 			RawData = new byte[RADIUS_HEADER_LENGTH];
 			RawData[RADIUS_CODE_INDEX] = (byte)PacketType;
 			RawData[RADIUS_IDENTIFIER_INDEX] = Identifier;
@@ -156,16 +155,16 @@ namespace FP.Radius
 					break;
 				case RadiusCode.ACCESS_CHALLENGE:
 					break;
-                case RadiusCode.COA_REQUEST:
-                    _Authenticator = Utils.AccountingRequestAuthenticator(RawData, sharedsecret);
-                    break;
-                case RadiusCode.DISCONNECT_REQUEST:
-                    _Authenticator = Utils.AccountingRequestAuthenticator(RawData, sharedsecret);
-                    break;
+				case RadiusCode.COA_REQUEST:
+					_Authenticator = Utils.AccountingRequestAuthenticator(RawData, sharedsecret);
+					break;
+				case RadiusCode.DISCONNECT_REQUEST:
+					_Authenticator = Utils.AccountingRequestAuthenticator(RawData, sharedsecret);
+					break;
 				default:
 					throw new ArgumentOutOfRangeException();
 			}
-			
+
 			Array.Copy(_Authenticator, 0, RawData, RADIUS_AUTHENTICATOR_INDEX, RADIUS_AUTHENTICATOR_FIELD_LENGTH);
 		}
 
@@ -176,7 +175,7 @@ namespace FP.Radius
 		}
 
 		public void SetAttribute(RadiusAttribute attribute)
-		{			
+		{
 			_Attributes.Add(attribute);
 
 			//Make an array with a size of the current RawData plus the new attribute
@@ -203,8 +202,8 @@ namespace FP.Radius
 			while (currentAttributeOffset < attributeByteArray.Length)
 			{
 				//Get the RADIUS attribute type
-				RadiusAttributeType type = (RadiusAttributeType) attributeByteArray[currentAttributeOffset];
-				
+				RadiusAttributeType type = (RadiusAttributeType)attributeByteArray[currentAttributeOffset];
+
 				//Get the RADIUS attribute length
 				byte length = attributeByteArray[currentAttributeOffset + 1];
 
@@ -220,8 +219,8 @@ namespace FP.Radius
 				Array.Copy(attributeByteArray, currentAttributeOffset + 2, data, 0, length - 2);
 
 				_Attributes.Add(type == RadiusAttributeType.VENDOR_SPECIFIC
-					                ? new VendorSpecificAttribute(attributeByteArray, currentAttributeOffset)
-					                : new RadiusAttribute(type, data));
+									? new VendorSpecificAttribute(attributeByteArray, currentAttributeOffset)
+									: new RadiusAttribute(type, data));
 
 				currentAttributeOffset += length;
 			}


### PR DESCRIPTION
The received packet should be returned to the user even if the authenticator fails.  Authenticator verification should be done after it's received and returned to the caller.