### PR TITLE
RadiusUtils: Clear sum instead of data.

### DIFF
--- a/Radius/Utils/RadiusUtils.cs
+++ b/Radius/Utils/RadiusUtils.cs
@@ -12,7 +12,7 @@ namespace FP.Radius
 
 			Array.Copy(data, 0, sum, 0, data.Length);
 			Array.Copy(sharedS, 0, sum, data.Length, sharedS.Length);
-			Array.Clear(data, 4, 16);
+			Array.Clear(sum, 4, 16);
 			MD5 md5 = new MD5CryptoServiceProvider();
 			md5.ComputeHash(sum, 0, sum.Length);
 			return md5.Hash;


### PR DESCRIPTION
Authenticator bytes should be set to zero before computing the Authenticator, instead currently the input is mutated. 

checkout this gist to demonstrate the bug https://gist.github.com/efraimglobus/e94eb95e784f039a633b74b9ff0dcbf5

currently, calling SetAuthenticator twice will result in different Authenticator

```
using FP.Radius;
using System.Diagnostics;
using System.Linq;

namespace ClientTest
{
	internal class Program
	{
		private static void Main(string[] args)
        {
            var sharedSecret = "sharedSecret";
            var radiusPacket = new RadiusPacket(RadiusCode.ACCOUNTING_REQUEST);
			radiusPacket.SetIdentifier(12);
			radiusPacket.SetAttribute(RadiusAttribute.CreateString(RadiusAttributeType.ACCT_AUTHENTIC, "test123"));
			radiusPacket.SetAuthenticator(sharedSecret);
            var radiusPacketAuthenticator1 = radiusPacket.Authenticator;
            radiusPacket.SetAuthenticator(sharedSecret);
            var radiusPacketAuthenticator2 = radiusPacket.Authenticator;
            Debug.Assert(Enumerable.SequenceEqual(radiusPacketAuthenticator1, radiusPacketAuthenticator2));
        }
    }
}
```